### PR TITLE
feat: 컨택트 및 푸터 섹션 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Visual from "./components/sections/Visual";
 import Projects from "./components/sections/Projects";
 import Works from "./components/sections/Works";
 import Contact from "./components/sections/Contact";
+import Footer from "./components/common/Footer";
 
 function App() {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -25,6 +26,7 @@ function App() {
         <Works />
         <Contact />
       </main>
+      <Footer />
     </ThemeProvider>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { darkTheme, lightTheme } from "./styles/theme";
 import Visual from "./components/sections/Visual";
 import Projects from "./components/sections/Projects";
 import Works from "./components/sections/Works";
+import Contact from "./components/sections/Contact";
 
 function App() {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -22,6 +23,7 @@ function App() {
         <About />
         <Projects />
         <Works />
+        <Contact />
       </main>
     </ThemeProvider>
   );

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import { IoMdArrowUp } from "react-icons/io";
+import styled from "styled-components";
+
+const FooterLayout = styled.footer`
+  width: 100%;
+  padding: 24px;
+  position: relative;
+
+  .copyright {
+    position: absolute;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.75rem;
+    color: #cacaca;
+  }
+`;
+
+const ScrollToTopButton = styled.button`
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  border-radius: 99px;
+  width: 45px;
+  height: 45px;
+  text-align: center;
+  line-height: 45px;
+  font-size: 1.25rem;
+  border: 1px solid #d2d2d2;
+  color: #b4b4b4;
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  transition: all 0.3s;
+
+  &:hover {
+    background-color: #efefef;
+  }
+`;
+
+function Footer() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY;
+      if (scrollTop > 500) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  return (
+    <FooterLayout>
+      <span className="copyright">ⓒ 2024 LeeSonga. All Rights Reserved.</span>
+
+      {isVisible && (
+        <ScrollToTopButton onClick={scrollToTop}>
+          <IoMdArrowUp />
+        </ScrollToTopButton>
+      )}
+    </FooterLayout>
+  );
+}
+
+export default Footer;

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,0 +1,100 @@
+import styled from "styled-components";
+import {
+  CenteredContentSection,
+  flexStyle,
+  StyledSubTitle,
+} from "../../styles/commonStyles";
+import LinkIcon from "../ui/LinkIcon";
+import { SiGmail } from "react-icons/si";
+import { MY_EMAIL, MY_GITHUB_URL } from "../../constants/urls";
+import { FaGithub } from "react-icons/fa";
+import devices from "../../constants/devices";
+
+const ContactSection = styled(CenteredContentSection)`
+  padding: 0 24px;
+  min-height: 60vh;
+
+  p {
+    text-align: center;
+    line-height: 1.4;
+  }
+
+  .link-icons {
+    ${flexStyle}
+    gap: 16px;
+    justify-content: center;
+    margin-top: 44px;
+
+    svg {
+      font-size: 2rem;
+    }
+
+    .link-icon {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      text-align: center;
+      transition: all 0.8s;
+
+      span {
+        opacity: 0;
+        color: var(--primary-color);
+        transition: all 0.5s;
+      }
+
+      &:hover {
+        color: var(--primary-color);
+
+        span {
+          opacity: 1;
+        }
+      }
+    }
+  }
+
+  @media ${devices.sm} {
+    .link-icons {
+      gap: 56px;
+
+      svg {
+        font-size: 4rem;
+      }
+    }
+  }
+`;
+
+const StyledSectionTitle = styled.h2`
+  font-size: 3.5rem;
+  text-align: center;
+  padding: 12px 0 32px 0;
+`;
+
+function Contact() {
+  return (
+    <ContactSection>
+      <StyledSubTitle>Contact</StyledSubTitle>
+      <StyledSectionTitle>방문해 주셔서 감사합니다 :)</StyledSectionTitle>
+      <p>
+        프론트엔드 개발자로서 끊임없이 성장하고 싶습니다. 낯선 기술에도 주저
+        없이 도전하고, 항상 사용자의 관점에서 생각하며 더 나은 서비스를 만들어
+        나가겠습니다.
+      </p>
+      <p>
+        함께 일하는 동료들과 협력하며, 서로 배우고 발전하는 과정을 통해 신뢰받는
+        개발자가 되겠습니다.
+      </p>
+      <div className="link-icons">
+        <div className="link-icon">
+          <LinkIcon href={MY_GITHUB_URL} icon={FaGithub} target="_blank" />
+          <span>Github</span>
+        </div>
+        <div className="link-icon">
+          <LinkIcon href={`mailto:${MY_EMAIL}`} icon={SiGmail} />
+          <span>Email</span>
+        </div>
+      </div>
+    </ContactSection>
+  );
+}
+
+export default Contact;


### PR DESCRIPTION
## 관련 이슈
#7 

## 작업 내용
- 프론트엔드 개발자로서의 성장 목표를 담은 `컨택트 섹션` 을 구현했습니다.
  - GitHub 및 이메일 링크 아이콘을 추가하여 소통 경로를 제공했습니다.
 - 저작권 표시와 스크롤 탑 버튼을 적절히 배치한 `푸터 섹션` 을 구현했습니다.
   - 페이지 스크롤이 500px 이상일 때 버튼이 화면에 나타나고, 클릭 시 부드럽게 페이지 맨 위로 스크롤됩니다.

## 스크린샷
![2024-11-20161226-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/a43e1b28-e34b-4ef4-8537-d0d29a382624)
